### PR TITLE
REPO-4250: REST API: Refactor TAS RESTAPI tests to not use CMIS

### DIFF
--- a/src/main/java/org/alfresco/utility/data/DataContent.java
+++ b/src/main/java/org/alfresco/utility/data/DataContent.java
@@ -237,7 +237,7 @@ public class DataContent extends TestData<DataContent>
      */
     public void deleteContentV1RestApi(AlfrescoHttpClient client)
     {
-        STEP(String.format("DATAPREP: Deleting '%s' with id '%s'", getLastResource(), getNodeRef()));
+        STEP(String.format("DATAPREP: Deleting '%s' with id '%s'", getLastResource(), getLastNodeId()));
 
         // Build request
         String nodeId = this.getLastNodeId();

--- a/src/main/java/org/alfresco/utility/data/DataContent.java
+++ b/src/main/java/org/alfresco/utility/data/DataContent.java
@@ -158,7 +158,7 @@ public class DataContent extends TestData<DataContent>
         STEP(String.format("DATAPREP: Create folder '%s' in %s", folderModel.getName(), getCurrentSpace()));
 
         // Build request
-        String nodeId = this.getNodeRef();
+        String nodeId = this.getLastNodeId();
         String reqUrl = client.getApiVersionUrl() + "nodes/" + nodeId + "/children";
         HttpPost post  = new HttpPost(reqUrl);
         JSONObject body = new JSONObject();
@@ -240,7 +240,7 @@ public class DataContent extends TestData<DataContent>
         STEP(String.format("DATAPREP: Deleting '%s' with id '%s'", getLastResource(), getNodeRef()));
 
         // Build request
-        String nodeId = this.getNodeRef();
+        String nodeId = this.getLastNodeId();
         String reqUrl = client.getApiVersionUrl() + "nodes/" + nodeId;
         HttpDelete delete  = new HttpDelete(reqUrl);
 
@@ -345,7 +345,7 @@ public class DataContent extends TestData<DataContent>
         STEP(String.format("DATAPREP: Create file '%s' in %s", fileModel.getName(), getCurrentSpace()));
 
         // Build request
-        String nodeId = this.getNodeRef();
+        String nodeId = this.getLastNodeId();
         String reqUrl = client.getApiVersionUrl() + "nodes/" + nodeId + "/children";
         HttpPost post  = new HttpPost(reqUrl);
         JSONObject body = new JSONObject();

--- a/src/main/java/org/alfresco/utility/dsl/DSL.java
+++ b/src/main/java/org/alfresco/utility/dsl/DSL.java
@@ -57,6 +57,16 @@ public interface DSL<Data>
     /**
      * Defines the current test site to be used
      * 
+     * @param siteId
+     * @return
+     * @throws Exception
+     */
+
+    Data usingSite(String siteId) throws Exception;
+
+    /**
+     * Defines the current test site to be used based on {@link SiteModel}
+     *
      * @param siteModel
      * @return
      * @throws Exception

--- a/src/main/java/org/alfresco/utility/dsl/DSL.java
+++ b/src/main/java/org/alfresco/utility/dsl/DSL.java
@@ -57,15 +57,6 @@ public interface DSL<Data>
     /**
      * Defines the current test site to be used
      * 
-     * @param siteId
-     * @return
-     * @throws Exception
-     */
-    Data usingSite(String siteId) throws Exception;
-
-    /**
-     * Defines the current test site to be used based on {@link SiteModel}
-     * 
      * @param siteModel
      * @return
      * @throws Exception

--- a/src/main/java/org/alfresco/utility/dsl/DSLProtocol.java
+++ b/src/main/java/org/alfresco/utility/dsl/DSLProtocol.java
@@ -216,6 +216,18 @@ public abstract class DSLProtocol<Client> extends DSLWrapper<Client> implements 
     @Override
     public abstract Client usingSite(SiteModel siteModel) throws Exception;
 
+    /**
+     * User for changing current site location This method will build the path
+     * of the siteId location Example: /Sites/<siteId>/documentLibrary Add
+     * implementation for your protocol accordingly
+     *
+     * @param siteId
+     * @return
+     * @throws Exception
+     */
+    @Override
+    public abstract Client usingSite(String siteId) throws Exception;
+
     @Override
     public abstract Client usingUserHome(String username) throws Exception;
 

--- a/src/main/java/org/alfresco/utility/dsl/DSLProtocol.java
+++ b/src/main/java/org/alfresco/utility/dsl/DSLProtocol.java
@@ -213,18 +213,6 @@ public abstract class DSLProtocol<Client> extends DSLWrapper<Client> implements 
 
     public abstract Client disconnect() throws Exception;
 
-    /**
-     * User for changing current site location This method will build the path
-     * of the siteId location Example: /Sites/<siteId>/documentLibrary Add
-     * implementation for your protocol accordingly
-     * 
-     * @param siteId
-     * @return
-     * @throws Exception
-     */
-    @Override
-    public abstract Client usingSite(String siteId) throws Exception;
-
     @Override
     public abstract Client usingSite(SiteModel siteModel) throws Exception;
 


### PR DESCRIPTION
- added lastNodeId used for resources. This is used when making rest calls instead of lastResource which is used for CMIS calls