### PR TITLE
Add Solr shared secret properties for ACS-2566

### DIFF
--- a/src/main/java/org/alfresco/utility/TasProperties.java
+++ b/src/main/java/org/alfresco/utility/TasProperties.java
@@ -179,6 +179,12 @@ public class TasProperties
 
     @Value("${solr.port:8983}")
     private int solrPort;
+
+    @Value("${solr.secretName:X-Alfresco-Search-Secret}")
+    private String solrSecretName;
+
+    @Value("${solr.secret:}")
+    private String solrSecret;
     
     @Value("${display.xport:1}")
     private String displayXport;
@@ -726,7 +732,27 @@ public class TasProperties
     {
         this.solrPort = solrPort;
     }
-    
+
+    public String getSolrSecretName()
+    {
+        return solrSecretName;
+    }
+
+    public void setSolrSecretName(String solrSecretName)
+    {
+        this.solrSecretName = solrSecretName;
+    }
+
+    public String getSolrSecret()
+    {
+        return solrSecret;
+    }
+
+    public void setSolrSecret(String solrSecret)
+    {
+        this.solrSecret = solrSecret;
+    }
+
     /**
      * @return host: <schema>://<server>
      */
@@ -742,4 +768,5 @@ public class TasProperties
     {
 		return displayXport;
 	}
+
 }

--- a/src/test/java/org/alfresco/utility/BeansTest.java
+++ b/src/test/java/org/alfresco/utility/BeansTest.java
@@ -121,6 +121,18 @@ public class BeansTest extends AbstractTestNGSpringContextTests
         Assert.assertNotNull(dataUser, "Bean DataUser is initialised");
     }
 
+    @Test
+    public void getDefaultSolrSecretName()
+    {
+        Assert.assertEquals(properties.getSolrSecretName(), "X-Alfresco-Search-Secret");
+    }
+
+    @Test
+    public void getDefaultSolrSecret()
+    {
+        Assert.assertTrue(properties.getSolrSecret().isEmpty());
+    }
+
     @Test(enabled=false)
     public void createFolderAndContent() throws Exception
     {


### PR DESCRIPTION
Add Solr shared secret properties in order to define the Solr secret header and value to be used for e2e tests.