### PR TITLE
ACS-3843 Add AlphabeticalPriorityInterceptor

### DIFF
--- a/src/main/java/org/alfresco/utility/testng/AlphabeticalPriorityInterceptor.java
+++ b/src/main/java/org/alfresco/utility/testng/AlphabeticalPriorityInterceptor.java
@@ -1,0 +1,26 @@
+package org.alfresco.utility.testng;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.testng.IMethodInstance;
+import org.testng.IMethodInterceptor;
+import org.testng.ITestContext;
+
+/**
+ * A method interceptor that sorts test classes alphabetically.
+ *
+ * @author Damian Ujma
+ */
+public class AlphabeticalPriorityInterceptor implements IMethodInterceptor
+{
+    @Override
+    public List<IMethodInstance> intercept(List<IMethodInstance> methods,
+                                           ITestContext context)
+    {
+        return methods.stream()
+                      .sorted(Comparator.comparing(methodInstance -> methodInstance.getMethod().getTestClass().getName()))
+                      .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
Moved `AlphabeticalPriorityInterceptor` from `alfresco-community-repo`.