### PR TITLE
ACS-4888 Remove Keycloak Dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Using a centralized location (Nexus), everyone will be able to reuse this indivi
 
 ## Prerequisite 
 (tested on unix/non-unix destribution)
-* [Java SE 1.8](http://www.oracle.com/technetwork/java/javase/downloads/index.html).
+* [Java 11](http://www.oracle.com/technetwork/java/javase/downloads/index.html).
 * [Maven 3.3](https://maven.apache.org/download.cgi) installed and configure according to [Windows OS](https://maven.apache.org/guides/getting-started/windows-prerequisites.html) or [Mac OS](https://maven.apache.org/install.html).
 * Configure Maven to use Alfresco alfresco-internal repository following this [Guide](https://ts.alfresco.com/share/page/site/eng/wiki-page?title=Maven_Setup).
 We are using also the internal-snapshot repository, so here it is the full settings.xml file

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.alfresco.tas</groupId>
     <artifactId>utility</artifactId>
     <name>alfresco-tas-utility</name>
-    <version>3.0.62-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-super-pom</artifactId>
@@ -32,13 +32,12 @@
         <extentreports.version>2.41.2</extentreports.version>
         <google.guava.version>23.0</google.guava.version>
         <google.gson.version>2.8.9</google.gson.version>
-        <jackson-databind.version>2.12.6.1</jackson-databind.version>
+        <dependency.jackson.version>2.14.2</dependency.jackson.version>
         <org.jvnet.version>0.6.5</org.jvnet.version>
         <javax.mail.version>1.6.2</javax.mail.version>
         <seleniumjava.version>3.141.59</seleniumjava.version>
         <yandex.qatools.version>1.20.0</yandex.qatools.version>
         <java.version>11</java.version>
-        <dependency.keycloak.version>18.0.0</dependency.keycloak.version>
         <apache.commons>3.11</apache.commons>
     </properties>
 
@@ -174,58 +173,21 @@
         </resources>
 
     </build>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>2.14.2</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
-        <!-- Keycloak dependencies-->
-        <dependency>
-            <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-admin-client</artifactId>
-            <version>${dependency.keycloak.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-common</artifactId>
-            <version>${dependency.keycloak.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-adapter-core</artifactId>
-            <version>${dependency.keycloak.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-core</artifactId>
-            <version>${dependency.keycloak.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-authz-client</artifactId>
-            <version>${dependency.keycloak.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jackson2-provider</artifactId>
@@ -328,13 +290,6 @@
             <groupId>com.relevantcodes</groupId>
             <artifactId>extentreports</artifactId>
             <version>${extentreports.version}</version>
-        </dependency>
-
-        <!-- @JsonProperty -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>${jackson-databind.version}</version>
         </dependency>
 
         <!-- JAXB in java 8, removed in java 11 -->

--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>2.14.2</version>
+                <version>${dependency.jackson.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/main/java/org/alfresco/utility/TasAisProperties.java
+++ b/src/main/java/org/alfresco/utility/TasAisProperties.java
@@ -1,12 +1,8 @@
 package org.alfresco.utility;
 
-import org.keycloak.representations.adapters.config.AdapterConfig;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
-
-import java.util.Map;
-import java.util.TreeMap;
 
 /**
  * Properties specific to Alfresco Identity Service.
@@ -16,8 +12,6 @@ import java.util.TreeMap;
 @PropertySource(value = "classpath:${environment}.properties", ignoreResourceNotFound = true)
 public class TasAisProperties
 {
-
-    AdapterConfig adapterConfig = null;
 
     @Value("${identity-service.realm:alfresco}")
     String realm;
@@ -159,71 +153,18 @@ public class TasAisProperties
         this.adminPassword = adminPassword;
     }
 
-    public AdapterConfig getAdapterConfig()
+    public String getAuthServerUrl()
     {
-        if (adapterConfig != null)
-        {
-            return adapterConfig;
-        }
+        return authServerUrl;
+    }
 
-        AdapterConfig adapterConfig = new AdapterConfig();
-        adapterConfig.setRealm(realm);
-        adapterConfig.setRealmKey(realmKey);
-        adapterConfig.setAuthServerUrl(authServerUrl);
-        adapterConfig.setSslRequired(sslRequired);
-        adapterConfig.setConfidentialPort(confidentialPort);
-        adapterConfig.setResource(resource);
-        adapterConfig.setUseResourceRoleMappings(useResourceRoleMappings);
-        adapterConfig.setCors(enableCors);
-        adapterConfig.setCorsMaxAge(corsMaxAge);
-        adapterConfig.setCorsAllowedHeaders(corsAllowedHeaders);
-        adapterConfig.setCorsAllowedMethods(corsAllowedMethods);
-        adapterConfig.setCorsExposedHeaders(corsExposedHeaders);
-        adapterConfig.setExposeToken(exposeToken);
-        adapterConfig.setBearerOnly(bearerOnly);
-        adapterConfig.setAutodetectBearerOnly(autodetectBearerOnly);
-        adapterConfig.setEnableBasicAuth(enableBasicAuth);
-        adapterConfig.setPublicClient(publicClient);
-        adapterConfig.setAllowAnyHostname(allowAnyHostname);
-        adapterConfig.setDisableTrustManager(disableTrustManager);
-        adapterConfig.setTruststore(truststore);
-        adapterConfig.setTruststorePassword(truststorePassword);
-        adapterConfig.setClientKeystore(clientKeystore);
-        adapterConfig.setClientKeystorePassword(clientKeystorePassword);
-        adapterConfig.setClientKeyPassword(clientKeyPassword);
-        adapterConfig.setConnectionPoolSize(connectionPoolSize);
-        adapterConfig.setAlwaysRefreshToken(alwaysRefreshToken);
-        adapterConfig.setRegisterNodeAtStartup(registerNodeAtStartup);
-        adapterConfig.setRegisterNodePeriod(registerNodePeriod);
-        adapterConfig.setTokenStore(tokenStore);
-        adapterConfig.setPrincipalAttribute(principalAttribute);
-        adapterConfig.setTurnOffChangeSessionIdOnLogin(turnOffChangeSessionIdOnLogin);
-        adapterConfig.setTokenMinimumTimeToLive(tokenMinimumTimeToLive);
-        adapterConfig.setMinTimeBetweenJwksRequests(minTimeBetweenJwksRequests);
-        adapterConfig.setPublicKeyCacheTtl(publicKeyCacheTtl);
-        adapterConfig.setPkce(enablePkce);
-        adapterConfig.setIgnoreOAuthQueryParameter(ignoreOAuthQueryParameter);
+    public String getRealm()
+    {
+        return realm;
+    }
 
-        // programmatically build the more complex objects i.e. credentials
-        Map<String, Object> credentials = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-        if (credentialsSecret != null)
-        {
-            credentials.put("secret", credentialsSecret);
-        }
-        else
-        {
-            credentials.put("secret", "");
-        }
-
-        if (credentialsProvider != null && !credentialsProvider.isEmpty())
-        {
-            credentials.put("provider", credentialsProvider);
-        }
-
-        adapterConfig.setCredentials(credentials);
-
-        this.adapterConfig = adapterConfig;
-
-        return adapterConfig;
+    public String getResource()
+    {
+        return resource;
     }
 }

--- a/src/main/java/org/alfresco/utility/data/auth/AISClient.java
+++ b/src/main/java/org/alfresco/utility/data/auth/AISClient.java
@@ -26,9 +26,9 @@ import com.google.gson.Gson;
 
 import org.junit.Assert;
 
-class IdsAdminClient
+class AISClient
 {
-    private String clientId;
+    private final String clientId;
     private final String adminUsername;
     private final String adminPassword;
     private final URI tokenUri;
@@ -36,7 +36,7 @@ class IdsAdminClient
     private final java.net.http.HttpClient httpClient;
     private static final Gson GSON = new Gson();
 
-    IdsAdminClient(String clientId, String adminUsername, String adminPassword, URI tokenUri, URI usersUri, java.net.http.HttpClient httpClient)
+    AISClient(String clientId, String adminUsername, String adminPassword, URI tokenUri, URI usersUri, java.net.http.HttpClient httpClient)
     {
         this.clientId = requireNonNull(clientId);
         this.adminUsername = requireNonNull(adminUsername);

--- a/src/main/java/org/alfresco/utility/data/auth/AISClient.java
+++ b/src/main/java/org/alfresco/utility/data/auth/AISClient.java
@@ -9,6 +9,7 @@ import static org.springframework.web.util.UriComponentsBuilder.fromUri;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublisher;
 import java.net.http.HttpRequest.BodyPublishers;
@@ -33,10 +34,10 @@ class AISClient
     private final String adminPassword;
     private final URI tokenUri;
     private final URI usersUri;
-    private final java.net.http.HttpClient httpClient;
+    private final HttpClient httpClient;
     private static final Gson GSON = new Gson();
 
-    AISClient(String clientId, String adminUsername, String adminPassword, URI tokenUri, URI usersUri, java.net.http.HttpClient httpClient)
+    AISClient(String clientId, String adminUsername, String adminPassword, URI tokenUri, URI usersUri, HttpClient httpClient)
     {
         this.clientId = requireNonNull(clientId);
         this.adminUsername = requireNonNull(adminUsername);

--- a/src/main/java/org/alfresco/utility/data/auth/DataAIS.java
+++ b/src/main/java/org/alfresco/utility/data/auth/DataAIS.java
@@ -187,7 +187,11 @@ public class DataAIS implements InitializingBean
         {
             long currentTime = System.currentTimeMillis();
             //AisToken token = new AisToken(tokenResponse.get("access_token"), tokenResponse.get("refresh_token"), currentTime, tokenResponse.getExpiresIn() * 1000);
-            AisToken token = new AisToken((String) tokenResponse.get("access_token"), (String) tokenResponse.get("refresh_token"), currentTime, 1234 * 1000);
+            AisToken token = new AisToken(
+                    (String) tokenResponse.get("access_token"),
+                    (String) tokenResponse.get("refresh_token"),
+                    currentTime,
+                    ((Number)tokenResponse.get("expires_in")).longValue() * 1000);
 
             aisTokens.put(key, token);
         }

--- a/src/main/java/org/alfresco/utility/data/auth/DataAIS.java
+++ b/src/main/java/org/alfresco/utility/data/auth/DataAIS.java
@@ -189,7 +189,7 @@ public class DataAIS implements InitializingBean
         public synchronized void addTokenForUser(Integer key, Map<String, ?> tokenResponse)
         {
             long currentTime = System.currentTimeMillis();
-            //AisToken token = new AisToken(tokenResponse.get("access_token"), tokenResponse.get("refresh_token"), currentTime, tokenResponse.getExpiresIn() * 1000);
+            
             AisToken token = new AisToken(
                     (String) tokenResponse.get("access_token"),
                     (String) tokenResponse.get("refresh_token"),

--- a/src/main/java/org/alfresco/utility/data/auth/DataAIS.java
+++ b/src/main/java/org/alfresco/utility/data/auth/DataAIS.java
@@ -1,6 +1,6 @@
 package org.alfresco.utility.data.auth;
 
-import static org.alfresco.utility.data.auth.IdsAdminClient.extractUserId;
+import static org.alfresco.utility.data.auth.AISClient.extractUserId;
 import static org.springframework.web.util.UriComponentsBuilder.fromUri;
 import static org.springframework.web.util.UriComponentsBuilder.fromUriString;
 
@@ -38,7 +38,7 @@ public class DataAIS implements InitializingBean
 
     @Autowired
     private TasAisProperties aisProperties;
-    private IdsAdminClient adminClient;
+    private AISClient aisClient;
 
     @Override
     public void afterPropertiesSet()
@@ -70,7 +70,7 @@ public class DataAIS implements InitializingBean
 
             // Configure http client
             final HttpClient httpClient = HttpClient.newHttpClient();
-            adminClient = new IdsAdminClient(resource, adminUsername, adminPassword, tokenUri, usersUri, httpClient);
+            aisClient = new AISClient(resource, adminUsername, adminPassword, tokenUri, usersUri, httpClient);
         }
     }
 
@@ -94,7 +94,7 @@ public class DataAIS implements InitializingBean
         @Override
         public Builder createUser(UserModel user)
         {
-            adminClient.createUser(user.getUsername(), user.getPassword(), user.getFirstName(), user.getLastName());
+            aisClient.createUser(user.getUsername(), user.getPassword(), user.getFirstName(), user.getLastName());
             return this;
         }
 
@@ -108,7 +108,7 @@ public class DataAIS implements InitializingBean
             {
                 removeTokenForUser(generateTokenKey(user));
 
-                adminClient.deleteUser(userId);
+                aisClient.deleteUser(userId);
             }
             return this;
         }
@@ -139,8 +139,8 @@ public class DataAIS implements InitializingBean
         {
             LOG.info(String.format("[AlfrescoIdentityService] Disable user %s", user.getUsername()));
             Map<String, Object> userRepresentation = findUserByUsername(user.getUsername());
-            IdsAdminClient.setEnabled(userRepresentation, false);
-            adminClient.updateUser(userRepresentation);
+            AISClient.setEnabled(userRepresentation, false);
+            aisClient.updateUser(userRepresentation);
             removeTokenForUser(generateTokenKey(user));
             return this;
         }
@@ -149,20 +149,20 @@ public class DataAIS implements InitializingBean
         {
             LOG.info(String.format("[AlfrescoIdentityService] Enable user %s", user.getUsername()));
             Map<String, Object> userRepresentation = findUserByUsername(user.getUsername());
-            IdsAdminClient.setEnabled(userRepresentation, true);
-            adminClient.updateUser(userRepresentation);
+            AISClient.setEnabled(userRepresentation, true);
+            aisClient.updateUser(userRepresentation);
             return this;
         }
 
         private Map<String, ?> obtainAccessToken(UserModel user)
         {
             LOG.info(String.format("[AlfrescoIdentityService] Obtain access token for user %s", user.getUsername()));
-            return adminClient.authorizeUser(user.getUsername(), user.getPassword());
+            return aisClient.authorizeUser(user.getUsername(), user.getPassword());
         }
 
         private Map<String, Object> findUserByUsername(String username)
         {
-            final List<Map<String, Object>> matchingUsers = adminClient.findUser(username);
+            final List<Map<String, Object>> matchingUsers = aisClient.findUser(username);
 
             if (matchingUsers.size() == 1)
             {

--- a/src/main/java/org/alfresco/utility/data/auth/DataAIS.java
+++ b/src/main/java/org/alfresco/utility/data/auth/DataAIS.java
@@ -1,6 +1,7 @@
 package org.alfresco.utility.data.auth;
 
 import static org.alfresco.utility.data.auth.AISClient.extractUserId;
+import static org.alfresco.utility.data.auth.AISClient.setEnabled;
 import static org.springframework.web.util.UriComponentsBuilder.fromUri;
 import static org.springframework.web.util.UriComponentsBuilder.fromUriString;
 
@@ -94,6 +95,8 @@ public class DataAIS implements InitializingBean
         @Override
         public Builder createUser(UserModel user)
         {
+            LOG.info(String.format("[AlfrescoIdentityService] Add user %s", user.getUsername()));
+
             aisClient.createUser(user.getUsername(), user.getPassword(), user.getFirstName(), user.getLastName());
             return this;
         }
@@ -139,7 +142,7 @@ public class DataAIS implements InitializingBean
         {
             LOG.info(String.format("[AlfrescoIdentityService] Disable user %s", user.getUsername()));
             Map<String, Object> userRepresentation = findUserByUsername(user.getUsername());
-            AISClient.setEnabled(userRepresentation, false);
+            setEnabled(userRepresentation, false);
             aisClient.updateUser(userRepresentation);
             removeTokenForUser(generateTokenKey(user));
             return this;
@@ -149,7 +152,7 @@ public class DataAIS implements InitializingBean
         {
             LOG.info(String.format("[AlfrescoIdentityService] Enable user %s", user.getUsername()));
             Map<String, Object> userRepresentation = findUserByUsername(user.getUsername());
-            AISClient.setEnabled(userRepresentation, true);
+            setEnabled(userRepresentation, true);
             aisClient.updateUser(userRepresentation);
             return this;
         }

--- a/src/main/java/org/alfresco/utility/data/auth/DataAIS.java
+++ b/src/main/java/org/alfresco/utility/data/auth/DataAIS.java
@@ -1,30 +1,21 @@
 package org.alfresco.utility.data.auth;
 
-import java.util.Arrays;
+import static org.alfresco.utility.data.auth.IdsAdminClient.extractUserId;
+import static org.springframework.web.util.UriComponentsBuilder.fromUri;
+import static org.springframework.web.util.UriComponentsBuilder.fromUriString;
+
+import java.net.URI;
+import java.net.http.HttpClient;
 import java.util.HashMap;
 import java.util.List;
-
-import javax.ws.rs.core.Response;
+import java.util.Map;
 
 import org.alfresco.utility.TasAisProperties;
 import org.alfresco.utility.data.AisToken;
 import org.alfresco.utility.model.UserModel;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.http.client.HttpClient;
-import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
-import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient4Engine;
 import org.junit.Assert;
-import org.keycloak.adapters.HttpClientBuilder;
-import org.keycloak.admin.client.Keycloak;
-import org.keycloak.admin.client.KeycloakBuilder;
-import org.keycloak.admin.client.resource.UsersResource;
-import org.keycloak.authorization.client.AuthzClient;
-import org.keycloak.authorization.client.Configuration;
-import org.keycloak.representations.AccessTokenResponse;
-import org.keycloak.representations.adapters.config.AdapterConfig;
-import org.keycloak.representations.idm.CredentialRepresentation;
-import org.keycloak.representations.idm.UserRepresentation;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
@@ -40,31 +31,29 @@ import org.springframework.stereotype.Service;
 @Scope(value = "prototype")
 public class DataAIS implements InitializingBean
 {
-    private static Log LOG = LogFactory.getLog(DataAIS.class);
-    private UsersResource usersResource;
-    private AuthzClient authzClient;
-    private boolean enabled;
-    private static HashMap<Integer, AisToken> aisTokens = new HashMap<>();
+    private static final Log LOG = LogFactory.getLog(DataAIS.class);
+    private static final HashMap<Integer, AisToken> aisTokens = new HashMap<>();
     private static final int TIMEOUT_DELTA_MILLISECONDS = 5000;
+    private boolean enabled;
 
     @Autowired
     private TasAisProperties aisProperties;
+    private IdsAdminClient adminClient;
 
     @Override
     public void afterPropertiesSet()
     {
-        AdapterConfig aisAdapterConfig = aisProperties.getAdapterConfig();
-        String authServerUrl = aisAdapterConfig.getAuthServerUrl();
+        String authServerUrl = aisProperties.getAuthServerUrl();
         if (authServerUrl != null && !authServerUrl.isEmpty())
         {
             enabled = true;
         }
 
-        // Check the minimal set of properties required to communicate with the keycloak server
+        // Check the minimal set of properties required to communicate with the AIS server
         if (enabled)
         {
-            String realm = aisAdapterConfig.getRealm();
-            String resource = aisAdapterConfig.getResource();
+            String realm = aisProperties.getRealm();
+            String resource = aisProperties.getResource();
             String adminUsername = aisProperties.getAdminUsername();
             String adminPassword = aisProperties.getAdminPassword();
 
@@ -73,52 +62,21 @@ public class DataAIS implements InitializingBean
             Assert.assertTrue("AIS adminUsername can not be empty", adminUsername!=null && !adminUsername.isEmpty());
             Assert.assertTrue("AIS adminPassword can not be empty", adminPassword!=null && !adminPassword.isEmpty());
 
-            LOG.info(String.format("[AlfrescoIdentityService] Building Keycloak clients. Url= %s ", authServerUrl));
+            LOG.info(String.format("[AlfrescoIdentityService] Building AIS clients. Url= %s ", authServerUrl));
+
+            URI issuerUri = fromUriString(authServerUrl).pathSegment("realms", realm).build().toUri();
+            URI tokenUri = fromUri(issuerUri).pathSegment("protocol", "openid-connect", "token").build().toUri();
+            URI usersUri = fromUriString(authServerUrl).pathSegment("admin", "realms", realm, "users").build().toUri();
 
             // Configure http client
-            HttpClient httpClient = new HttpClientBuilder()
-                    .build(aisAdapterConfig);
-            ApacheHttpClient4Engine httpEngine = new ApacheHttpClient4Engine(httpClient);
-
-            // Configure usersResource
-            Keycloak  keycloak = KeycloakBuilder
-                .builder()
-                .serverUrl(authServerUrl)
-                .realm(realm)
-                .username(adminUsername)
-                .password(adminPassword)
-                .clientId(resource)
-                .resteasyClient(new ResteasyClientBuilder()
-                    .httpEngine(httpEngine)
-                    .build())
-                .build();
-            usersResource = keycloak.realm(realm).users();
-
-            // Configure authzClient
-            Configuration authzConfig = new Configuration(authServerUrl, realm, resource,
-                aisAdapterConfig.getCredentials(), httpClient);
-            authzClient = AuthzClient.create(authzConfig);
+            final HttpClient httpClient = HttpClient.newHttpClient();
+            adminClient = new IdsAdminClient(resource, adminUsername, adminPassword, tokenUri, usersUri, httpClient);
         }
     }
 
     public boolean isEnabled()
     {
         return enabled;
-    }
-
-    public void setUsersResource(UsersResource usersResource)
-    {
-        this.usersResource = usersResource;
-    }
-
-    public void setAuthzClient(AuthzClient authzClient)
-    {
-        this.authzClient = authzClient;
-    }
-
-    public void setAisProperties(TasAisProperties aisProperties)
-    {
-        this.aisProperties = aisProperties;
     }
 
     public DataAIS.Builder perform()
@@ -136,25 +94,7 @@ public class DataAIS implements InitializingBean
         @Override
         public Builder createUser(UserModel user)
         {
-            LOG.info(String.format("[AlfrescoIdentityService] Add user %s", user.getUsername()));
-
-            CredentialRepresentation credential = new CredentialRepresentation();
-            credential.setType(CredentialRepresentation.PASSWORD);
-            credential.setValue(user.getPassword());
-            credential.setTemporary(false);
-
-            UserRepresentation userRepresentation = new UserRepresentation();
-            userRepresentation.setUsername(user.getUsername());
-            userRepresentation.setFirstName(user.getFirstName());
-            userRepresentation.setLastName(user.getLastName());
-            userRepresentation.setCredentials(Arrays.asList(credential));
-            userRepresentation.setEnabled(true);
-
-            Response response = usersResource.create(userRepresentation);
-            Assert.assertTrue("Failed to create user in Keycloak: " + response.getStatusInfo(),
-                    response.getStatusInfo().equals(Response.Status.CREATED));
-            response.close();
-
+            adminClient.createUser(user.getUsername(), user.getPassword(), user.getFirstName(), user.getLastName());
             return this;
         }
 
@@ -163,13 +103,12 @@ public class DataAIS implements InitializingBean
         {
             LOG.info(String.format("[AlfrescoIdentityService] Delete user %s", user.getUsername()));
 
-            UserRepresentation userRepresentation = findUserByUsername(user.getUsername());
-            if (userRepresentation != null)
+            String userId = extractUserId(findUserByUsername(user.getUsername()));
+            if (userId != null)
             {
                 removeTokenForUser(generateTokenKey(user));
 
-                Response response = usersResource.delete(userRepresentation.getId());
-                response.close();
+                adminClient.deleteUser(userId);
             }
             return this;
         }
@@ -199,55 +138,56 @@ public class DataAIS implements InitializingBean
         public Builder disableUser(UserModel user)
         {
             LOG.info(String.format("[AlfrescoIdentityService] Disable user %s", user.getUsername()));
-            UserRepresentation userRepresentation = findUserByUsername(user.getUsername());
-            userRepresentation.setEnabled(false);
-            usersResource.get(userRepresentation.getId()).update(userRepresentation);
+            Map<String, Object> userRepresentation = findUserByUsername(user.getUsername());
+            IdsAdminClient.setEnabled(userRepresentation, false);
+            adminClient.updateUser(userRepresentation);
             removeTokenForUser(generateTokenKey(user));
             return this;
         }
 
         public Builder enableUser(UserModel user)
         {
-            LOG.info(String.format("[AlfrescoIdentityService] Disable user %s", user.getUsername()));
-            UserRepresentation userRepresentation = findUserByUsername(user.getUsername());
-            userRepresentation.setEnabled(true);
-            usersResource.get(userRepresentation.getId()).update(userRepresentation);
+            LOG.info(String.format("[AlfrescoIdentityService] Enable user %s", user.getUsername()));
+            Map<String, Object> userRepresentation = findUserByUsername(user.getUsername());
+            IdsAdminClient.setEnabled(userRepresentation, true);
+            adminClient.updateUser(userRepresentation);
             return this;
         }
 
-        public AccessTokenResponse obtainAccessToken(UserModel user)
+        private Map<String, ?> obtainAccessToken(UserModel user)
         {
             LOG.info(String.format("[AlfrescoIdentityService] Obtain access token for user %s", user.getUsername()));
-            return authzClient.obtainAccessToken(user.getUsername(), user.getPassword());
+            return adminClient.authorizeUser(user.getUsername(), user.getPassword());
         }
 
-        public UserRepresentation findUserByUsername(String username)
+        private Map<String, Object> findUserByUsername(String username)
         {
-            UserRepresentation user = null;
-            List<UserRepresentation> ur = usersResource.search(username, null, null, null, 0, Integer.MAX_VALUE);
-            if (ur.size() == 1)
+            final List<Map<String, Object>> matchingUsers = adminClient.findUser(username);
+
+            if (matchingUsers.size() == 1)
             {
-                user = ur.get(0);
+                return matchingUsers.get(0);
             }
 
-            if (ur.size() > 1) // try to be more specific
+            if (matchingUsers.size() > 1) // try to be more specific
             {
-                for (UserRepresentation rep : ur)
+                for (Map<String, Object> user : matchingUsers)
                 {
-                    if (rep.getUsername().equalsIgnoreCase(username))
+                    if (username.equalsIgnoreCase((String)user.get("username")))
                     {
-                        return rep;
+                        return user;
                     }
                 }
             }
 
-            return user;
+            return null;
         }
 
-        public synchronized void addTokenForUser(Integer key, AccessTokenResponse tokenResponse)
+        public synchronized void addTokenForUser(Integer key, Map<String, ?> tokenResponse)
         {
-            Long currentTime = System.currentTimeMillis();
-            AisToken token = new AisToken(tokenResponse.getToken(), tokenResponse.getRefreshToken(), currentTime, tokenResponse.getExpiresIn() * 1000);
+            long currentTime = System.currentTimeMillis();
+            //AisToken token = new AisToken(tokenResponse.get("access_token"), tokenResponse.get("refresh_token"), currentTime, tokenResponse.getExpiresIn() * 1000);
+            AisToken token = new AisToken((String) tokenResponse.get("access_token"), (String) tokenResponse.get("refresh_token"), currentTime, 1234 * 1000);
 
             aisTokens.put(key, token);
         }
@@ -259,15 +199,12 @@ public class DataAIS implements InitializingBean
 
         public Boolean checkTokenValidity(Integer key)
         {
-            Long currentTime = System.currentTimeMillis();
+            long currentTime = System.currentTimeMillis();
 
             if (aisTokens.containsKey(key))
             {
                 AisToken token = aisTokens.get(key);
-                if (currentTime < (token.getExpirationTime() - TIMEOUT_DELTA_MILLISECONDS))
-                {
-                    return true;
-                }
+                return currentTime < (token.getExpirationTime() - TIMEOUT_DELTA_MILLISECONDS);
             }
 
             return false;
@@ -287,8 +224,8 @@ public class DataAIS implements InitializingBean
             if(!checkTokenValidity(key))
             {
                 //Get and add new user token
-                AccessTokenResponse tokenReponse = obtainAccessToken(user);
-                addTokenForUser(key, tokenReponse);
+                Map<String, ?> tokenResponse = obtainAccessToken(user);
+                addTokenForUser(key, tokenResponse);
             }
 
             return aisTokens.get(key);

--- a/src/main/java/org/alfresco/utility/data/auth/IdsAdminClient.java
+++ b/src/main/java/org/alfresco/utility/data/auth/IdsAdminClient.java
@@ -1,0 +1,196 @@
+package org.alfresco.utility.data.auth;
+
+import static java.lang.String.format;
+import static java.net.URLEncoder.encode;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+import static org.springframework.web.util.UriComponentsBuilder.fromUri;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublisher;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.google.gson.Gson;
+
+import org.junit.Assert;
+
+class IdsAdminClient
+{
+    private String clientId;
+    private final String adminUsername;
+    private final String adminPassword;
+    private final URI tokenUri;
+    private final URI usersUri;
+    private final java.net.http.HttpClient httpClient;
+    private static final Gson GSON = new Gson();
+
+    IdsAdminClient(String clientId, String adminUsername, String adminPassword, URI tokenUri, URI usersUri, java.net.http.HttpClient httpClient)
+    {
+        this.clientId = requireNonNull(clientId);
+        this.adminUsername = requireNonNull(adminUsername);
+        this.adminPassword = requireNonNull(adminPassword);
+        this.tokenUri = requireNonNull(tokenUri);
+        this.usersUri = requireNonNull(usersUri);
+        this.httpClient = requireNonNull(httpClient);
+    }
+
+    Map<String, ?> authorizeUser(String username, String password)
+    {
+        final HttpRequest request = createFormPostRequest(tokenUri, Map.of(
+                "grant_type", "password",
+                "username", username,
+                "password", password,
+                "client_id", clientId));
+
+        String response = getResponse(request, requireOkStatus(r -> format("Failed to obtain AIS User (%s) Access Token: %s", username, r.body())));
+
+        return GSON.fromJson(response, Map.class);
+    }
+
+    List<Map<String, Object>> findUser(String username)
+    {
+        final URI uri = fromUri(usersUri)
+                .queryParam("username", username)
+                .queryParam("first", 0)
+                .queryParam("max", Integer.MAX_VALUE)
+                .build().toUri();
+        final HttpRequest request = authenticatedRequestBuilder(uri).GET().build();
+
+        String response = getResponse(request, requireOkStatus(r -> "Failed to search for users: " + r.body()));
+
+        return GSON.fromJson(response, List.class);
+    }
+
+    void createUser(String username, String password, String firstName, String lastName)
+    {
+        final HttpRequest request = authenticatedRequestBuilder(usersUri)
+                .header("Content-Type", "application/json;charset=UTF-8")
+                .POST(asJson(Map.of(
+                        "username", username,
+                        "firstName", firstName,
+                        "lastName", lastName,
+                        "enabled", true,
+                        "credentials", List.of(Map.of(
+                                "type", "password",
+                                "value", password,
+                                "temporary", false)))))
+                .build();
+
+        getResponse(request, requireCreatedStatus(r -> "Failed to create AIS user: " + r.body()));
+    }
+
+    void deleteUser(String userId)
+    {
+        final URI uri = fromUri(usersUri).pathSegment(userId).build().toUri();
+        final HttpRequest request = authenticatedRequestBuilder(uri).DELETE().build();
+
+        getResponse(request, requireNoContentStatus(r -> "Failed to delete AIS user: " + r.body()));
+    }
+
+    void updateUser(Map<String, Object> user)
+    {
+        final URI uri = fromUri(usersUri).pathSegment(extractUserId(user)).build().toUri();
+        final HttpRequest request = authenticatedRequestBuilder(uri)
+                .header("Content-Type", "application/json;charset=UTF-8")
+                .PUT(asJson(user)).build();
+
+        getResponse(request, requireNoContentStatus(r -> "Failed to save AIS user: " + r.body()));
+    }
+
+    private HttpRequest.Builder authenticatedRequestBuilder(URI uri)
+    {
+        final String accessToken = getAdminAccessToken();
+        return HttpRequest.newBuilder(uri)
+                          .header("Authorization", "Bearer " + accessToken)
+                          .header("Accept", "application/json");
+    }
+
+    private String getAdminAccessToken()
+    {
+        final Map<String, ?> authorization = authorizeUser(adminUsername, adminPassword);
+        return (String) authorization.get("access_token");
+    }
+
+    private Consumer<HttpResponse<?>> requireNoContentStatus(Function<HttpResponse<?>, String> message)
+    {
+        return requireStatus(204, message);
+    }
+
+    private Consumer<HttpResponse<?>> requireCreatedStatus(Function<HttpResponse<?>, String> message)
+    {
+        return requireStatus(201, message);
+    }
+
+    private Consumer<HttpResponse<?>> requireOkStatus(Function<HttpResponse<?>, String> message)
+    {
+        return requireStatus(200, message);
+    }
+
+    private Consumer<HttpResponse<?>> requireStatus(int expectedStatus, Function<HttpResponse<?>, String> message)
+    {
+        return r -> Assert.assertEquals(message.apply(r), expectedStatus, r.statusCode());
+    }
+
+    private String getResponse(HttpRequest request, Consumer<HttpResponse<?>>... responseValidators)
+    {
+        try
+        {
+            final HttpResponse<String> response = httpClient.send(request, BodyHandlers.ofString());
+            Stream.of(responseValidators).forEach(v -> v.accept(response));
+            return response.body();
+        } catch (IOException e)
+        {
+            throw new IllegalStateException(e);
+        } catch (InterruptedException e)
+        {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private HttpRequest createFormPostRequest(URI uri, Map<String, String> formParams)
+    {
+        String encodedForm = formParams.entrySet()
+                                       .stream()
+                                       .map(e -> e.getKey() + "=" + encode(e.getValue(), UTF_8))
+                                       .collect(Collectors.joining("&"));
+
+        return HttpRequest.newBuilder()
+                          .uri(uri)
+                          .headers("Content-Type", "application/x-www-form-urlencoded")
+                          .header("Accept", "application/json")
+                          .POST(BodyPublishers.ofString(encodedForm))
+                          .build();
+    }
+
+    static void setEnabled(Map<String, Object> user, boolean isEnabled)
+    {
+        user.put("enabled", isEnabled);
+    }
+
+    static String extractUserId(Map<String, ?> user)
+    {
+        return Optional.ofNullable(user)
+                       .map(u -> u.get("id"))
+                       .filter(String.class::isInstance)
+                       .map(String.class::cast)
+                       .orElse(null);
+    }
+
+    private static BodyPublisher asJson(Map<String, ?> map)
+    {
+        return BodyPublishers.ofString(GSON.toJson(map));
+    }
+}


### PR DESCRIPTION
This PR removes Keycloak dependencies. This should be a new major release because it might break existing code for following reasons:
* some methods are private now (they were returning Keycloak specific classes anyway)
* Keycloak is no longer provided as a transitive dependency which might cause issues when someone relied on Keycloak classes/exceptions