### PR TITLE
ACS-4799: Elasticsearch query feature expansion - boosts

### DIFF
--- a/src/main/java/org/alfresco/utility/data/DataContent.java
+++ b/src/main/java/org/alfresco/utility/data/DataContent.java
@@ -181,6 +181,18 @@ public class DataContent extends TestData<DataContent>
         JSONObject body = new JSONObject();
         body.put("name", folderModel.getName());
         body.put("nodeType", "cm:folder");
+
+        JSONObject properties = new JSONObject();
+        if (folderModel.getTitle() != null)
+        {
+            properties.put("cm:title", folderModel.getTitle());
+        }
+        if (folderModel.getDescription() != null)
+        {
+            properties.put("cm:description", folderModel.getDescription());
+        }
+        body.put("properties", properties);
+
         post.setEntity(client.setMessageBody(body));
 
         // Send Request


### PR DESCRIPTION
Preparing E2Es for search boosts.
- Fixing issue with setting folder's title and description in E2E tests.

https://alfresco.atlassian.net/browse/ACS-4799