### PR TITLE
ACS-8114 Populate email for new AIS users

### DIFF
--- a/src/main/java/org/alfresco/utility/data/auth/AISClient.java
+++ b/src/main/java/org/alfresco/utility/data/auth/AISClient.java
@@ -74,12 +74,13 @@ class AISClient
         return GSON.fromJson(response, List.class);
     }
 
-    void createUser(String username, String password, String firstName, String lastName)
+    void createUser(String username, String password, String firstName, String lastName, String email)
     {
         final HttpRequest request = authenticatedRequestBuilder(usersUri)
                 .header("Content-Type", "application/json;charset=UTF-8")
                 .POST(asJson(Map.of(
                         "username", username,
+                        "email", email,
                         "firstName", firstName,
                         "lastName", lastName,
                         "enabled", true,

--- a/src/main/java/org/alfresco/utility/data/auth/DataAIS.java
+++ b/src/main/java/org/alfresco/utility/data/auth/DataAIS.java
@@ -97,7 +97,7 @@ public class DataAIS implements InitializingBean
         {
             LOG.info(String.format("[AlfrescoIdentityService] Add user %s", user.getUsername()));
 
-            aisClient.createUser(user.getUsername(), user.getPassword(), user.getFirstName(), user.getLastName());
+            aisClient.createUser(user.getUsername(), user.getPassword(), user.getFirstName(), user.getLastName(), user.getEmailAddress());
             return this;
         }
 


### PR DESCRIPTION
For new realms on Keycloak 24 the `email` has become a required user profile field. To make sure our tests work both with migrated realms and entirely new realms _(such as the one that is being used by Terraform environments)_, it would be better to always populate the email.

This change especially makes sense to me as the email is already being populated for the Alfresco test users within ACS, so there's probably no good reason to not mirror that information onto AIS as well.

Ref:
- https://www.keycloak.org/docs/latest/upgrading/index.html#default-validations