### PR TITLE
[ACS-10904] Upgrade selenium java dependency alfresco-tas-utility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,4 +17,4 @@ jobs:
     uses: Alfresco/alfresco-build-tools/.github/workflows/build-and-release-maven.yml@v12.4.2
     secrets: inherit
     with:
-      release-branches: "^master$|^release/.+$"
+      release-branches: "^master$"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build_and_release:
     name: "Build and Release"
-    uses: Alfresco/alfresco-build-tools/.github/workflows/build-and-release-maven.yml@v7.0.0
+    uses: Alfresco/alfresco-build-tools/.github/workflows/build-and-release-maven.yml@v12.0.0
     secrets: inherit
     with:
       release-branches: "^master$|^release/.+$"

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.alfresco.tas</groupId>
     <artifactId>utility</artifactId>
     <name>alfresco-tas-utility</name>
-    <version>5.0.3-SNAPSHOT</version>
+    <version>5.0.3</version>
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-super-pom</artifactId>
@@ -48,7 +48,7 @@
         <connection>scm:git:https://github.com/Alfresco/alfresco-tas-utility.git</connection>
         <developerConnection>scm:git:https://github.com/Alfresco/alfresco-tas-utility.git</developerConnection>
         <url>https://github.com/Alfresco/alfresco-tas-utility</url>
-        <tag>HEAD</tag>
+        <tag>utility-5.0.3</tag>
     </scm>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <dependency.jackson.version>2.14.2</dependency.jackson.version>
         <org.jvnet.version>0.6.5</org.jvnet.version>
         <dependency.jakarta-ee-mail.version>2.0.1</dependency.jakarta-ee-mail.version>
-        <seleniumjava.version>4.38.0</seleniumjava.version>
+        <seleniumjava.version>4.40.0</seleniumjava.version>
         <apache.commons>3.11</apache.commons>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.alfresco.tas</groupId>
     <artifactId>utility</artifactId>
     <name>alfresco-tas-utility</name>
-    <version>5.0.4</version>
+    <version>5.0.5-SNAPSHOT</version>
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-super-pom</artifactId>
@@ -48,7 +48,7 @@
         <connection>scm:git:https://github.com/Alfresco/alfresco-tas-utility.git</connection>
         <developerConnection>scm:git:https://github.com/Alfresco/alfresco-tas-utility.git</developerConnection>
         <url>https://github.com/Alfresco/alfresco-tas-utility</url>
-        <tag>utility-5.0.4</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <dependency.jackson.version>2.14.2</dependency.jackson.version>
         <org.jvnet.version>0.6.5</org.jvnet.version>
         <dependency.jakarta-ee-mail.version>2.0.1</dependency.jakarta-ee-mail.version>
-        <seleniumjava.version>3.141.59</seleniumjava.version>
+        <seleniumjava.version>4.38.0</seleniumjava.version>
         <yandex.qatools.version>1.20.0</yandex.qatools.version>
         <apache.commons>3.11</apache.commons>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -355,13 +355,6 @@
             <version>${seleniumjava.version}</version>
         </dependency>
 
-        <!-- yandex -->
-        <dependency>
-            <groupId>ru.yandex.qatools.htmlelements</groupId>
-            <artifactId>htmlelements-java</artifactId>
-            <version>${yandex.qatools.version}</version>
-        </dependency>
-
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.alfresco.tas</groupId>
     <artifactId>utility</artifactId>
     <name>alfresco-tas-utility</name>
-    <version>5.0.5-SNAPSHOT</version>
+    <version>5.0.5</version>
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-super-pom</artifactId>
@@ -47,7 +47,7 @@
         <connection>scm:git:https://github.com/Alfresco/alfresco-tas-utility.git</connection>
         <developerConnection>scm:git:https://github.com/Alfresco/alfresco-tas-utility.git</developerConnection>
         <url>https://github.com/Alfresco/alfresco-tas-utility</url>
-        <tag>HEAD</tag>
+        <tag>utility-5.0.5</tag>
     </scm>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.alfresco.tas</groupId>
     <artifactId>utility</artifactId>
     <name>alfresco-tas-utility</name>
-    <version>5.0.5</version>
+    <version>5.0.6-SNAPSHOT</version>
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-super-pom</artifactId>
@@ -47,7 +47,7 @@
         <connection>scm:git:https://github.com/Alfresco/alfresco-tas-utility.git</connection>
         <developerConnection>scm:git:https://github.com/Alfresco/alfresco-tas-utility.git</developerConnection>
         <url>https://github.com/Alfresco/alfresco-tas-utility</url>
-        <tag>utility-5.0.5</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.alfresco.tas</groupId>
     <artifactId>utility</artifactId>
     <name>alfresco-tas-utility</name>
-    <version>5.0.4-SNAPSHOT</version>
+    <version>5.0.4</version>
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-super-pom</artifactId>
@@ -48,7 +48,7 @@
         <connection>scm:git:https://github.com/Alfresco/alfresco-tas-utility.git</connection>
         <developerConnection>scm:git:https://github.com/Alfresco/alfresco-tas-utility.git</developerConnection>
         <url>https://github.com/Alfresco/alfresco-tas-utility</url>
-        <tag>HEAD</tag>
+        <tag>utility-5.0.4</tag>
     </scm>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.alfresco.tas</groupId>
     <artifactId>utility</artifactId>
     <name>alfresco-tas-utility</name>
-    <version>5.0.3</version>
+    <version>5.0.4-SNAPSHOT</version>
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-super-pom</artifactId>
@@ -48,7 +48,7 @@
         <connection>scm:git:https://github.com/Alfresco/alfresco-tas-utility.git</connection>
         <developerConnection>scm:git:https://github.com/Alfresco/alfresco-tas-utility.git</developerConnection>
         <url>https://github.com/Alfresco/alfresco-tas-utility</url>
-        <tag>utility-5.0.3</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,6 @@
         <org.jvnet.version>0.6.5</org.jvnet.version>
         <dependency.jakarta-ee-mail.version>2.0.1</dependency.jakarta-ee-mail.version>
         <seleniumjava.version>4.38.0</seleniumjava.version>
-        <yandex.qatools.version>1.20.0</yandex.qatools.version>
         <apache.commons>3.11</apache.commons>
     </properties>
 
@@ -351,11 +350,11 @@
         </dependency>
 
         <!-- yandex -->
-        <dependency>
-            <groupId>ru.yandex.qatools.htmlelements</groupId>
-            <artifactId>htmlelements-java</artifactId>
-            <version>${yandex.qatools.version}</version>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>ru.yandex.qatools.htmlelements</groupId>-->
+<!--            <artifactId>htmlelements-java</artifactId>-->
+<!--            <version>${yandex.qatools.version}</version>-->
+<!--        </dependency>-->
 
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/src/main/java/org/alfresco/utility/data/auth/DataNtlmPassthru.java
+++ b/src/main/java/org/alfresco/utility/data/auth/DataNtlmPassthru.java
@@ -4,13 +4,12 @@ import static org.alfresco.utility.report.log.Step.STEP;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 import org.alfresco.utility.TasProperties;
 import org.alfresco.utility.Utility;
-import org.openqa.selenium.Platform;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
@@ -19,6 +18,7 @@ import org.springframework.stereotype.Service;
 /**
  * Created by Claudia Agache on 6/23/2017.
  * https://support.microsoft.com/en-in/help/322684/how-to-use-the-directory-service-command-line-tools-to-manage-active-directory-objects-in-windows-server-2003
+   Updated By Swarnajit Adhikary on 12/17/2025
  */
 @Service
 @Scope(value = "prototype")
@@ -60,15 +60,12 @@ public class DataNtlmPassthru
 
     private WebDriver setDriver() throws MalformedURLException
     {
-        DesiredCapabilities cap = DesiredCapabilities.firefox();
-        cap.setBrowserName("firefox");
-        cap.setPlatform(Platform.WIN8);
-        cap.setCapability("marionette", true);
-        cap.setCapability("network.automatic-ntlm-auth.trusted-uris", tasProperties.getTestServerUrl());
+        FirefoxOptions options = new FirefoxOptions();
+        options.setCapability("network.automatic-ntlm-auth.trusted-uris", tasProperties.getTestServerUrl());
 
-        WebDriver driver = new RemoteWebDriver(new URL(String.format("%s/wd/hub", hub)), cap);
-        driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
-        driver.manage().timeouts().pageLoadTimeout(30, TimeUnit.SECONDS);
+        WebDriver driver = new RemoteWebDriver(new URL(String.format("%s/wd/hub", hub)), options);
+        driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(10));
+        driver.manage().timeouts().pageLoadTimeout(Duration.ofSeconds(30));
 
         return driver;
     }

--- a/src/main/java/org/alfresco/utility/web/HtmlPage.java
+++ b/src/main/java/org/alfresco/utility/web/HtmlPage.java
@@ -75,7 +75,7 @@ public abstract class HtmlPage extends WebDriverAware
      */
     public String getPageTitle()
     {
-        return browser.getTitle();
+        return browser.getDriver().getTitle();
     }
 
     /**

--- a/src/main/java/org/alfresco/utility/web/browser/Browser.java
+++ b/src/main/java/org/alfresco/utility/web/browser/Browser.java
@@ -12,49 +12,68 @@ import org.apache.commons.lang3.SystemUtils;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
-import org.openqa.selenium.firefox.FirefoxBinary;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.firefox.GeckoDriverService;
 import org.openqa.selenium.ie.InternetExplorerDriver;
-import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.safari.SafariDriver;
 
 /**
  * Return differed DesiredCapabilities for {@link WebDriver}
- * 
+ *
  * @author Paul.Brodner
  */
 public enum Browser
 {
-    FIREFOX(DesiredCapabilities.firefox()),
-    CHROME(DesiredCapabilities.chrome()),
-    //HTMLUNIT(DesiredCapabilities.htmlUnit()),
-    INTERNETEXPLORER(DesiredCapabilities.internetExplorer()),
-    OPERA(DesiredCapabilities.operaBlink()),
-    HTMLINITDRIVER(DesiredCapabilities.htmlUnit()),
+    FIREFOX {
+                @Override
+                public WebDriver createWebDriver(TasProperties properties) {
+                    setFirefoxDriver();
+                    FirefoxOptions options = setFirefoxOptions(properties);
+                    if (SystemUtils.IS_OS_LINUX) {
+                        options.addArguments("--headless");
+                        Map<String, String> env = new HashMap<>();
+                        env.put("DISPLAY", ":" + properties.getDisplayXport());
+                        return new FirefoxDriver(new GeckoDriverService.Builder().withEnvironment(env).build(), options);
+                    } else {
+                        return new FirefoxDriver(options);
+                    }
+                }
+            },
+    CHROME {
+        @Override
+        public WebDriver createWebDriver(TasProperties properties) {
+            setChromeDriver();
+            HashMap<String, Object> chromePrefs = new HashMap<>();
+            chromePrefs.put("profile.default_content_settings.popups", 0);
+            chromePrefs.put("download.default_directory", getDownloadLocation());
 
-    /*
-     * Add Safari-Driver extension prior to tests
-     * http://selenium-release.storage.googleapis.com/2.48/SafariDriver.safariextz
-     */
-    SAFARI(DesiredCapabilities.safari());
+            ChromeOptions chromeOptions = new ChromeOptions();
+            chromeOptions.addArguments("--start-maximized");
+            chromeOptions.addArguments(String.format("--lang=%s", getBrowserLanguage(properties)));
+            chromeOptions.setExperimentalOption("prefs", chromePrefs);
+            return new ChromeDriver(chromeOptions);
+        }
+    },
+    //HTMLUNIT(DesiredCapabilities.htmlUnit()),
+    INTERNETEXPLORER {
+        @Override
+        public WebDriver createWebDriver(TasProperties properties) {
+            return new InternetExplorerDriver();
+        }
+    },
+    SAFARI {
+        @Override
+        public WebDriver createWebDriver(TasProperties properties) {
+            return new SafariDriver();
+        }
+    };
+
+    public abstract WebDriver createWebDriver(TasProperties properties);
 
     public static Browser getBrowserFromProperties(TasProperties properties)
     {
         return valueOf(properties.getBrowserName().toUpperCase());
-    }
-
-    private final DesiredCapabilities capabilities;
-
-    Browser(DesiredCapabilities caps)
-    {
-        this.capabilities = caps;
-    }
-
-    public DesiredCapabilities getCapabilities()
-    {
-        return capabilities;
     }
 
     /*
@@ -91,19 +110,17 @@ public enum Browser
         {
             case "firefox":
                 setFirefoxDriver();
+                FirefoxOptions firefoxOptions = setFirefoxOptions(properties);
                 if (SystemUtils.IS_OS_LINUX)
                 {
-                    FirefoxBinary firefoxBinary = new FirefoxBinary();
-                    firefoxBinary.addCommandLineOptions("--headless");
+                    firefoxOptions.addArguments("--headless");
                     Map<String, String> env = new HashMap<String, String>();
                     env.put("DISPLAY", ":" + properties.getDisplayXport());
-                    FirefoxOptions options1 = setFirefoxOptions(properties);
-                    options1.setBinary(firefoxBinary);
-                    return new FirefoxDriver(new GeckoDriverService.Builder().withEnvironment(env).build(), options1);
+                    return new FirefoxDriver(new GeckoDriverService.Builder().withEnvironment(env).build(), firefoxOptions);
                 }
                 else
                 {
-                    return new FirefoxDriver(setFirefoxOptions(properties));
+                    return new FirefoxDriver(firefoxOptions);
                 }
             case "chrome":
                 setChromeDriver();
@@ -111,12 +128,11 @@ public enum Browser
                 chromePrefs.put("profile.default_content_settings.popups", 0);
                 chromePrefs.put("download.default_directory", getDownloadLocation());
 
-                ChromeOptions options = new ChromeOptions();
-                options.addArguments("--start-maximized");
-                options.addArguments(String.format("--lang=%s", getBrowserLanguage(properties)));
-                options.setExperimentalOption("prefs", chromePrefs);
-                ChromeDriver chromeDriver = new ChromeDriver(options);
-                return chromeDriver;
+                ChromeOptions chromeOptions = new ChromeOptions();
+                chromeOptions.addArguments("--start-maximized");
+                chromeOptions.addArguments(String.format("--lang=%s", getBrowserLanguage(properties)));
+                chromeOptions.setExperimentalOption("prefs", chromePrefs);
+                return new ChromeDriver(chromeOptions);
             case "ie":
                 return new InternetExplorerDriver();
             //case "htmlunit":
@@ -172,7 +188,7 @@ public enum Browser
         String testDataFolder = srcRoot + "testdata" + File.separator;
         return testDataFolder;
     }
-    
+
     private static String getBrowserLanguage(TasProperties properties)
     {
         if(!StringUtils.isEmpty(properties.getBrowserLanguageCountry()))
@@ -181,6 +197,4 @@ public enum Browser
         }
         return properties.getBrowserLanguage();
     }
-    
-   
 }

--- a/src/main/java/org/alfresco/utility/web/browser/Browser.java
+++ b/src/main/java/org/alfresco/utility/web/browser/Browser.java
@@ -19,27 +19,29 @@ import org.openqa.selenium.ie.InternetExplorerDriver;
 import org.openqa.selenium.safari.SafariDriver;
 
 /**
- * Return differed DesiredCapabilities for {@link WebDriver}
+ *  * Provides browser-specific configurations and creates corresponding {@link WebDriver}
+ *  * instances using Selenium options classes (for example {@link FirefoxOptions},
+ *  * {@link ChromeOptions}, etc.).
  *
  * @author Paul.Brodner
  */
 public enum Browser
 {
     FIREFOX {
-                @Override
-                public WebDriver createWebDriver(TasProperties properties) {
-                    setFirefoxDriver();
-                    FirefoxOptions options = setFirefoxOptions(properties);
-                    if (SystemUtils.IS_OS_LINUX) {
-                        options.addArguments("--headless");
-                        Map<String, String> env = new HashMap<>();
-                        env.put("DISPLAY", ":" + properties.getDisplayXport());
-                        return new FirefoxDriver(new GeckoDriverService.Builder().withEnvironment(env).build(), options);
-                    } else {
-                        return new FirefoxDriver(options);
-                    }
-                }
-            },
+        @Override
+        public WebDriver createWebDriver(TasProperties properties) {
+            setFirefoxDriver();
+            FirefoxOptions options = setFirefoxOptions(properties);
+            if (SystemUtils.IS_OS_LINUX) {
+                options.addArguments("--headless");
+                Map<String, String> env = new HashMap<>();
+                env.put("DISPLAY", ":" + properties.getDisplayXport());
+                return new FirefoxDriver(new GeckoDriverService.Builder().withEnvironment(env).build(), options);
+            } else {
+                return new FirefoxDriver(options);
+            }
+        }
+    },
     CHROME {
         @Override
         public WebDriver createWebDriver(TasProperties properties) {

--- a/src/main/java/org/alfresco/utility/web/browser/EventWebBrowserListener.java
+++ b/src/main/java/org/alfresco/utility/web/browser/EventWebBrowserListener.java
@@ -56,7 +56,7 @@ public class EventWebBrowserListener implements WebDriverListener {
         String targetName = (target != null) ? target.getClass().getSimpleName() : "Unknown target";
         String methodName = (method != null) ? method.getName() : "Unknown method";
 
-        LOG.error("Error occurred in [{}] while calling method [{}] with args {}",
+        LOG.error("Error occurred in [{}] while calling method [{}] with throwable {}",
                 targetName, methodName, cause);
     }
 

--- a/src/main/java/org/alfresco/utility/web/browser/EventWebBrowserListener.java
+++ b/src/main/java/org/alfresco/utility/web/browser/EventWebBrowserListener.java
@@ -1,169 +1,70 @@
 package org.alfresco.utility.web.browser;
 
+import org.openqa.selenium.Alert;
 import org.openqa.selenium.By;
-import org.openqa.selenium.OutputType;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.events.WebDriverEventListener;
+import org.openqa.selenium.support.events.WebDriverListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * Logger class for {@link WebDriver}
- * 
- * @author Paul.Brodner
- */
-public class EventWebBrowserListener implements WebDriverEventListener
-{
-    private static final Logger LOG = LoggerFactory.getLogger(EventWebBrowserListener.class);
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
+public class EventWebBrowserListener implements WebDriverListener {
+    private static final Logger LOG = LoggerFactory.getLogger(EventWebBrowserListener.class);
     private String oldValue;
 
-    public void beforeChangeValueOf(WebElement arg0, WebDriver arg1)
-    {
-        oldValue = arg0.getAttribute("value");
-    }
-
-    public void afterChangeValueOf(WebElement arg0, WebDriver arg1)
-    {
-        String elementName = getElementName(arg0);
-        try
-        {
-            String newValue = arg0.getAttribute("value");
-            if (!newValue.equals(oldValue))
-            {
-                if (newValue.length() == 0)
-                {
-                    LOG.info("[{}] - cleared value", elementName);
-                }
-                else
-                {
-                    LOG.info("[{}] - changed value to '{}'", elementName, newValue);
-                }
-            }
-        }
-        catch (Exception e)
-        {
-            LOG.debug("[{}] - changed value", elementName);
-        }
+    @Override
+    public void beforeClick(WebElement element) {
+        LOG.debug("Trying to click '{}'", getElementName(element));
     }
 
     @Override
-    public void afterClickOn(WebElement arg0, WebDriver arg1)
-    {
-        LOG.info("Clicked on element '{}'", arg0);
+    public void afterClick(WebElement element) {
+        LOG.info("Clicked on element '{}'", getElementName(element));
     }
 
     @Override
-    public void afterFindBy(By arg0, WebElement arg1, WebDriver arg2)
-    {
-        LOG.debug("'{}' - found", arg0);
+    public void afterFindElement(WebDriver driver, By by, WebElement element) {
+        LOG.debug("'{}' - found", by);
     }
 
     @Override
-    public void afterNavigateBack(WebDriver arg0)
-    {
+    public void afterBack(WebDriver.Navigation navigation) {
         LOG.info("Navigated Back");
     }
 
     @Override
-    public void afterNavigateForward(WebDriver arg0)
-    {
+    public void afterForward(WebDriver.Navigation driver) {
         LOG.info("Navigated Forward");
     }
 
     @Override
-    public void afterNavigateTo(String arg0, WebDriver arg1)
-    {
-        LOG.info("Navigate to '{}'", arg0);
+    public void afterGet(WebDriver driver, String url) {
+        LOG.info("Navigate to '{}'", url);
     }
 
     @Override
-    public void afterScript(String arg0, WebDriver arg1)
-    {
-        LOG.info("Ran script '{}'", arg0);
+    public void afterExecuteScript(WebDriver driver, String script, Object[] args, Object result) {
+        LOG.info("Ran script '{}'", script);
     }
 
     @Override
-    public void beforeSwitchToWindow(String s, WebDriver webDriver)
-    {
+    public void onError(Object target, Method method, Object[] args, InvocationTargetException e) {
+        Throwable cause = e.getCause(); // unwrap the actual exception
+        String targetName = (target != null) ? target.getClass().getSimpleName() : "Unknown target";
+        String methodName = (method != null) ? method.getName() : "Unknown method";
 
+        LOG.error("Error occurred in [{}] while calling method [{}] with args {}",
+                targetName, methodName, cause);
     }
 
-    @Override
-    public void afterSwitchToWindow(String s, WebDriver webDriver)
-    {
-
-    }
-
-    @Override
-    public void beforeClickOn(WebElement arg0, WebDriver arg1)
-    {
-        LOG.debug("Trying to click '{}'", getElementName(arg0));
-    }
-
-    @Override
-    public void beforeFindBy(By arg0, WebElement arg1, WebDriver arg2)
-    {
-    }
-
-    @Override
-    public void beforeNavigateBack(WebDriver arg0)
-    {
-    }
-
-    @Override
-    public void beforeNavigateForward(WebDriver arg0)
-    {
-    }
-
-    @Override
-    public void beforeNavigateTo(String arg0, WebDriver arg1)
-    {
-    }
-
-    @Override
-    public void beforeScript(String arg0, WebDriver arg1)
-    {
-
-    }
-
-    @Override
-    public void onException(Throwable arg0, WebDriver arg1)
-    {
-        LOG.error(arg0.getClass().getName(), arg0);
-    }
-
-    @Override
-    public <X> void beforeGetScreenshotAs(OutputType<X> outputType)
-    {
-
-    }
-
-    @Override
-    public <X> void afterGetScreenshotAs(OutputType<X> outputType, X x)
-    {
-
-    }
-
-    @Override
-    public void beforeGetText(WebElement webElement, WebDriver webDriver) {
-
-    }
-
-    @Override
-    public void afterGetText(WebElement webElement, WebDriver webDriver, String s) {
-
-    }
-
-    private String getElementName(WebElement arg0)
-    {
-        String foundBy = arg0.toString();
-        if (foundBy != null)
-        {
+    private String getElementName(WebElement element) {
+        String foundBy = element.toString();
+        if (foundBy != null) {
             int arrowIndex = foundBy.indexOf("->");
-            if (arrowIndex >= 0)
-            {
+            if (arrowIndex >= 0) {
                 return "By." + foundBy.substring(arrowIndex + 3, foundBy.length() - 1);
             }
         }
@@ -171,56 +72,38 @@ public class EventWebBrowserListener implements WebDriverEventListener
     }
 
     @Override
-    public void beforeNavigateRefresh(WebDriver driver)
-    {
-
-    }
-
-    @Override
-    public void afterNavigateRefresh(WebDriver driver)
-    {
-
-    }
-
-    @Override
-    public void afterAlertAccept(WebDriver arg0)
+    public void beforeRefresh(WebDriver.Navigation navigation)
     {
         // TODO Auto-generated method stub
-        
     }
 
     @Override
-    public void afterAlertDismiss(WebDriver arg0)
+    public void afterRefresh(WebDriver.Navigation navigation)
     {
         // TODO Auto-generated method stub
-        
     }
 
     @Override
-    public void afterChangeValueOf(WebElement arg0, WebDriver arg1, CharSequence[] arg2)
+    public void afterAccept(Alert alert)
     {
         // TODO Auto-generated method stub
-        
     }
 
     @Override
-    public void beforeAlertAccept(WebDriver arg0)
+    public void afterDismiss(Alert alert)
     {
         // TODO Auto-generated method stub
-        
     }
 
     @Override
-    public void beforeAlertDismiss(WebDriver arg0)
+    public void beforeAccept(Alert alert)
     {
         // TODO Auto-generated method stub
-        
     }
 
     @Override
-    public void beforeChangeValueOf(WebElement arg0, WebDriver arg1, CharSequence[] arg2)
+    public void beforeDismiss(Alert alert)
     {
         // TODO Auto-generated method stub
-        
     }
 }

--- a/src/main/java/org/alfresco/utility/web/browser/WebBrowser.java
+++ b/src/main/java/org/alfresco/utility/web/browser/WebBrowser.java
@@ -167,7 +167,7 @@ public class WebBrowser
     public WebElement waitUntilElementVisible(By locator, long timeOutInSeconds)
     {
         Parameter.checkIsMandotary("Locator", locator);
-        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(properties.getExplicitWait()));
+        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(timeOutInSeconds));
         return wait.until(ExpectedConditions.visibilityOfElementLocated(locator));
     }
     
@@ -181,7 +181,7 @@ public class WebBrowser
     public WebElement waitUntilElementIsPresent(By locator, long timeOutInSeconds)
     {
         Parameter.checkIsMandotary("Locator", locator);
-        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(properties.getExplicitWait()));
+        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(timeOutInSeconds));
         return wait.until(ExpectedConditions.presenceOfElementLocated(locator));
     }
     
@@ -239,7 +239,7 @@ public class WebBrowser
     {
         Parameter.checkIsMandotary("Parent locator", parentLocator);
         Parameter.checkIsMandotary("Child locator", childLocator);
-        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(properties.getExplicitWait()));
+        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(timeOutInSeconds));
         return wait.until(ExpectedConditions.presenceOfNestedElementLocatedBy(parentLocator, childLocator));
     }
     
@@ -277,7 +277,7 @@ public class WebBrowser
     public WebElement waitUntilElementVisible(WebElement element, long timeOutInSeconds)
     {
         Parameter.checkIsMandotary("Element", element);
-        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(properties.getExplicitWait()));
+        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(timeOutInSeconds));
         return wait.until(ExpectedConditions.visibilityOf(element));
     }
 
@@ -522,7 +522,7 @@ public class WebBrowser
     public void waitUrlContains(String URLfraction, long timeOutInSeconds)
     {
         Parameter.checkIsMandotary("Element", URLfraction);
-        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(properties.getExplicitWait()));
+        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(timeOutInSeconds));
         wait.until(ExpectedConditions.urlContains(URLfraction));
     }
 
@@ -545,7 +545,7 @@ public class WebBrowser
     public void waitUntilElementDeletedFromDom(By locator, long timeOutInSeconds)
     {
         Parameter.checkIsMandotary("Locator", locator);
-        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(properties.getExplicitWait()));
+        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(timeOutInSeconds));
         try
         {
             wait.until(ExpectedConditions.stalenessOf(driver.findElement(locator)));
@@ -587,7 +587,7 @@ public class WebBrowser
     public void waitUntilElementDisappears(WebElement locator, long timeOutInSeconds)
     {
         Parameter.checkIsMandotary("Locator", locator);
-        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(properties.getExplicitWait()));
+        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(timeOutInSeconds));
         wait.until(ExpectedConditions.invisibilityOf(locator));
     }
 

--- a/src/main/java/org/alfresco/utility/web/browser/WebBrowser.java
+++ b/src/main/java/org/alfresco/utility/web/browser/WebBrowser.java
@@ -1257,26 +1257,33 @@ public class WebBrowser
         return elementsList.stream().map(WebElement::getText).collect(Collectors.toList());
     }
 
-    public WebDriver.Navigation navigate() { return driver.navigate(); }
+    public WebDriver.Navigation navigate()
+    {
+        return driver.navigate();
+    }
 
     public WebDriver getDriver()
     {
         return driver;
     }
 
-    public WebElement findElement(By by) {
+    public WebElement findElement(By by)
+    {
         return driver.findElement(by);
     }
 
-    public java.util.List<WebElement> findElements(By by) {
+    public java.util.List<WebElement> findElements(By by)
+    {
         return driver.findElements(by);
     }
 
-    public WebDriver.TargetLocator switchTo() {
+    public WebDriver.TargetLocator switchTo()
+    {
         return driver.switchTo();
     }
 
-    public String getCurrentUrl() {
+    public String getCurrentUrl()
+    {
         return driver.getCurrentUrl();
     }
 

--- a/src/main/java/org/alfresco/utility/web/browser/WebBrowserFactory.java
+++ b/src/main/java/org/alfresco/utility/web/browser/WebBrowserFactory.java
@@ -20,7 +20,6 @@ import org.springframework.stereotype.Component;
  * Take a look on {@link ContextAwareParallelSampleTest} for a simple example on how to use it
  * 
  * @author Paul.Brodner
- * @updated By Swarnajit Adhikary
  */
 @Component
 public class WebBrowserFactory implements FactoryBean<WebBrowser>

--- a/src/main/java/org/alfresco/utility/web/browser/WebDriverAware.java
+++ b/src/main/java/org/alfresco/utility/web/browser/WebDriverAware.java
@@ -10,9 +10,6 @@ import org.alfresco.utility.web.HtmlPage;
 import org.openqa.selenium.support.PageFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import ru.yandex.qatools.htmlelements.loader.decorator.HtmlElementDecorator;
-import ru.yandex.qatools.htmlelements.loader.decorator.HtmlElementLocatorFactory;
-
 public abstract class WebDriverAware
 {
     protected WebBrowser browser;
@@ -31,7 +28,7 @@ public abstract class WebDriverAware
         }
 
         this.browser = webBrowser;
-        PageFactory.initElements(new HtmlElementDecorator(new HtmlElementLocatorFactory(webBrowser.getDriver())), this);
+        PageFactory.initElements(webBrowser.getDriver(), this);
 
         List<Field> allFields = getAllDeclaredFields(new LinkedList<Field>(), this.getClass());
         for (Field field : allFields)

--- a/src/main/java/org/alfresco/utility/web/browser/WebDriverAware.java
+++ b/src/main/java/org/alfresco/utility/web/browser/WebDriverAware.java
@@ -16,12 +16,12 @@ import ru.yandex.qatools.htmlelements.loader.decorator.HtmlElementLocatorFactory
 public abstract class WebDriverAware
 {
     protected WebBrowser browser;
-    
+
     public WebBrowser getBrowser()
     {
-        return browser;                
+        return browser;
     }
-    
+
     public void setBrowser(WebBrowser webBrowser)
     {
         if (webBrowser.equals(this.browser))
@@ -31,7 +31,7 @@ public abstract class WebDriverAware
         }
 
         this.browser = webBrowser;
-        PageFactory.initElements(new HtmlElementDecorator(new HtmlElementLocatorFactory(webBrowser)), this);
+        PageFactory.initElements(new HtmlElementDecorator(new HtmlElementLocatorFactory(webBrowser.getDriver())), this);
 
         List<Field> allFields = getAllDeclaredFields(new LinkedList<Field>(), this.getClass());
         for (Field field : allFields)

--- a/src/main/java/org/alfresco/utility/web/renderer/RenderClickable.java
+++ b/src/main/java/org/alfresco/utility/web/renderer/RenderClickable.java
@@ -6,6 +6,8 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
+import java.time.Duration;
+
 /**
  * Render one element using selenium's expectedCondition.
  * Just annotate your {@link PageObject} with
@@ -22,7 +24,7 @@ public class RenderClickable extends RenderElement
     @Override
     protected void doWork(By locator, WebBrowser browser, long timeOutInSeconds)
     {
-        WebDriverWait wait = new WebDriverWait(browser, timeOutInSeconds);
+        WebDriverWait wait = new WebDriverWait(browser.getDriver(), Duration.ofSeconds(timeOutInSeconds));
         wait.until(ExpectedConditions.elementToBeClickable(locator));
     }
 }

--- a/src/main/java/org/alfresco/utility/web/renderer/RenderDeleted.java
+++ b/src/main/java/org/alfresco/utility/web/renderer/RenderDeleted.java
@@ -3,8 +3,11 @@ package org.alfresco.utility.web.renderer;
 import org.alfresco.utility.web.browser.WebBrowser;
 import org.alfresco.utility.web.annotation.PageObject;
 import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.time.Duration;
 
 /**
  * Render one element using selenium's expectedCondition.
@@ -16,13 +19,14 @@ import org.openqa.selenium.support.ui.WebDriverWait;
  * {code}
  * 
  * @author Paul.Brodner
+ * updated By Swarnajit Adhikary
  */
-public class RenderDeleted extends RenderElement
-{
+public class RenderDeleted extends RenderElement {
+
     @Override
-    public void doWork(By locator, WebBrowser browser, long timeOutInSeconds)
-    {
-        WebDriverWait wait = new WebDriverWait(browser, timeOutInSeconds);
-        wait.until(ExpectedConditions.stalenessOf(browser.findElement(locator)));
+    public void doWork(By locator, WebBrowser browser, long timeOutInSeconds) {
+        WebDriver driver = browser.getDriver();
+        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(timeOutInSeconds));
+        wait.until(ExpectedConditions.stalenessOf(driver.findElement(locator)));
     }
 }

--- a/src/main/java/org/alfresco/utility/web/renderer/RenderInvisible.java
+++ b/src/main/java/org/alfresco/utility/web/renderer/RenderInvisible.java
@@ -6,6 +6,8 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
+import java.time.Duration;
+
 /**
  * Render one element using selenium's expectedCondition.
  * Just annotate your {@link PageObject} with
@@ -22,7 +24,7 @@ public class RenderInvisible extends RenderElement
     @Override
     protected void doWork(By locator, WebBrowser browser, long timeOutInSeconds)
     {
-        WebDriverWait wait = new WebDriverWait(browser, timeOutInSeconds);
+        WebDriverWait wait = new WebDriverWait(browser.getDriver(), Duration.ofSeconds(timeOutInSeconds));
         wait.until(ExpectedConditions.invisibilityOfElementLocated(locator));
     }
 }

--- a/src/main/java/org/alfresco/utility/web/renderer/RenderInvisibleWithText.java
+++ b/src/main/java/org/alfresco/utility/web/renderer/RenderInvisibleWithText.java
@@ -6,6 +6,8 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
+import java.time.Duration;
+
 /**
  * Render one element using selenium's expectedCondition.
  * Just annotate your {@link PageObject} with
@@ -22,7 +24,7 @@ public class RenderInvisibleWithText extends RenderElement
     @Override
     protected void doWork(By locator, WebBrowser browser, long timeOutInSeconds)
     {
-        WebDriverWait wait = new WebDriverWait(browser, timeOutInSeconds);
+        WebDriverWait wait = new WebDriverWait(browser.getDriver(), Duration.ofSeconds(timeOutInSeconds));
         wait.until(ExpectedConditions.invisibilityOfElementWithText(locator, renderAnnotation.text()));
     }
 }

--- a/src/main/java/org/alfresco/utility/web/renderer/RenderPageLoaded.java
+++ b/src/main/java/org/alfresco/utility/web/renderer/RenderPageLoaded.java
@@ -9,6 +9,8 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
+import java.time.Duration;
+
 /**
  * Render one element using selenium's expectedCondition.
  * Just annotate your {@link PageObject} with
@@ -60,7 +62,7 @@ public class RenderPageLoaded extends RenderElement
         };
         try
         {
-            new WebDriverWait(browser, timeOutInSeconds).until(expectation);
+            new WebDriverWait(browser.getDriver(), Duration.ofSeconds(timeOutInSeconds)).until(expectation);
         }
         catch (TimeoutException exception)
         {

--- a/src/main/java/org/alfresco/utility/web/renderer/RenderPresent.java
+++ b/src/main/java/org/alfresco/utility/web/renderer/RenderPresent.java
@@ -6,6 +6,8 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
+import java.time.Duration;
+
 /**
  * Render one element using selenium's expectedCondition.
  * Just annotate your {@link PageObject} with
@@ -22,7 +24,7 @@ public class RenderPresent extends RenderElement
     @Override
     protected void doWork(By locator, WebBrowser browser, long timeOutInSeconds)
     {
-        WebDriverWait wait = new WebDriverWait(browser, timeOutInSeconds);
+        WebDriverWait wait = new WebDriverWait(browser.getDriver(), Duration.ofSeconds(timeOutInSeconds));
         wait.until(ExpectedConditions.presenceOfElementLocated(locator));
     }
 }

--- a/src/main/java/org/alfresco/utility/web/renderer/RenderVisible.java
+++ b/src/main/java/org/alfresco/utility/web/renderer/RenderVisible.java
@@ -3,8 +3,11 @@ package org.alfresco.utility.web.renderer;
 import org.alfresco.utility.web.browser.WebBrowser;
 import org.alfresco.utility.web.annotation.PageObject;
 import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.time.Duration;
 
 /**
  * Render one element using selenium's expectedCondition.
@@ -22,7 +25,8 @@ public class RenderVisible extends RenderElement
     @Override
     public void doWork(By locator, WebBrowser browser, long timeOutInSeconds)
     {
-        WebDriverWait wait = new WebDriverWait(browser, timeOutInSeconds);
+        WebDriver driver = browser.getDriver();
+        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(timeOutInSeconds));
         wait.until(ExpectedConditions.visibilityOfElementLocated(locator));
     }
 }

--- a/src/test/java/org/alfresco/utility/report/json/JsonReportTest.java
+++ b/src/test/java/org/alfresco/utility/report/json/JsonReportTest.java
@@ -1,6 +1,5 @@
 package org.alfresco.utility.report.json;
 
-import org.alfresco.utility.report.json.JsonReportListener;
 import org.testng.Assert;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;


### PR DESCRIPTION
The changes include upgrading Selenium to version 4, replacing deprecated APIs, refactoring browser driver creation, and updating event listener implementations.

1. Upgraded Selenium Java dependency from version 3.141.59 to 4.38.0 in `pom.xml`, enabling use of the latest Selenium features and APIs.
2. Replaced usage of deprecated `DesiredCapabilities` and older API patterns with `FirefoxOptions`, `ChromeOptions`, and direct driver instantiation throughout the codebase.
3. Updated timeout management to use `java.time.Duration` instead of legacy `TimeUnit`-based methods.
4. Refactored the `Browser` enum to use factory methods for driver creation, removing static capability fields and supporting headless mode for Firefox on Linux.
5. Updated browser-related utility methods and driver instantiation logic to use new options classes and patterns.
6. Migrated from the deprecated `WebDriverEventListener` to the new `WebDriverListener` interface in `EventWebBrowserListener`, updating method signatures and event handling logic for compatibility with Selenium 4.
7. Improved exception handling and logging in the event listener to provide clearer error reporting.
8. Refactored the `WebBrowser` class to wrap a `WebDriver` instance directly instead of extending `EventFiringWebDriver`, updating all usages accordingly.
9. Updated all browser interaction methods (navigation, actions, cookies, JavaScript execution, etc.) to use the wrapped driver, ensuring compatibility with the new structure.
10. Fixed a method call in `HtmlPage` to use the updated driver getter.